### PR TITLE
fix: compatibility with environments without crypto

### DIFF
--- a/formatters/html/formatter.ts
+++ b/formatters/html/formatter.ts
@@ -19,7 +19,15 @@ import type { HTMLFormatterConfig, HTMLPrinterStyles } from './types.js'
 const seed = 'useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict'
 export let nanoid = (length = 15) => {
   let output = ''
-  const random = crypto.getRandomValues(new Uint8Array(length))
+  let random = new Uint8Array(length)
+  if (globalThis.crypto) {
+    crypto.getRandomValues(random)
+  } else {
+    for (let i = 0; i < length; i++) {
+      random[i] = Math.floor(Math.random() * 256)
+    }
+  }
+
   for (let n = 0; n < length; n++) {
     output += seed[63 & random[n]]
   }


### PR DESCRIPTION
`globalThis.crypto` used for nanoid internal is unavailable for Node.js 18 (which is still supported by nuxt, nitro, and wrangler cli for example).

I have made a small polyfill as fallback that unlocks nitro to keep using upstream youch 4.x 🙏🏼 

followup youch PR: https://github.com/poppinss/youch/pull/69